### PR TITLE
Dynamically calculate counter from posts

### DIFF
--- a/_includes/incident_counter.html
+++ b/_includes/incident_counter.html
@@ -1,0 +1,1 @@
+{% assign counter = 0 %}{% for item in site.posts %}{% unless item.published == false %}{% assign counter=counter | plus:1 %}{% endunless %}{% endfor %}{{ counter }}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ layout: default
 
   <div class="section">
     <h1 class="section-header">Root Cause Estimates</h1>
-    The data below is roughly gleaned from publicly available data about <b>48</b> incidents. This should assist estimation during threat modeling.
+    The data below is roughly gleaned from publicly available data about <b>{% include incident_counter.html %}</b> incidents. This should assist estimation during threat modeling.
 
     {% include chart.html %}
   </div>


### PR DESCRIPTION
If all posts are incidents, no need to manually update count
Note, this results in 49 incidents, rather than the 48 currently
reported, which aligns with the number of items in _posts